### PR TITLE
remove 0.12.x nodejs from rpi1 library

### DIFF
--- a/library/raspberrypi-node
+++ b/library/raspberrypi-node
@@ -3,15 +3,23 @@
 
 0.10.40: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10
 0.10: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10
+0: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10
+latest: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10
 
 0.10.40-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.10/onbuild
 0.10-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.10/onbuild
+0-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.10/onbuild
+onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.10/onbuild
 
 0.10.40-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/slim
 0.10-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/slim
+0-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/slim
+slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/slim
 
 0.10.40-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/wheezy
 0.10-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/wheezy
+0-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/wheezy
+wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.10/wheezy
 
 0.11.16: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.11
 0.11: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.11
@@ -24,26 +32,6 @@
 
 0.11.16-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.11/wheezy
 0.11-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.11/wheezy
-
-0.12.7: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12
-0.12: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12
-0: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12
-latest: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12
-
-0.12.7-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.12/onbuild
-0.12-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.12/onbuild
-0-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.12/onbuild
-onbuild: git://github.com/resin-io-library/base-images@c4f86f276a6da51e6c063b00ba52df0ad86f47c3 node/raspberrypi/0.12/onbuild
-
-0.12.7-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/slim
-0.12-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/slim
-0-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/slim
-slim: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/slim
-
-0.12.7-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/wheezy
-0.12-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/wheezy
-0-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/wheezy
-wheezy: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.12/wheezy
 
 0.9.12: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.9
 0.9: git://github.com/resin-io-library/base-images@4df1311c1ca1df7be056a759030c7eb571d2be54 node/raspberrypi/0.9


### PR DESCRIPTION
nodejs 0.12.x doesn't work on rpi1, that's why they are removed