### PR TITLE
Update libraries for <arch>-node base-images:

### DIFF
--- a/library/amd64-node
+++ b/library/amd64-node
@@ -1,16 +1,17 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
+0.10.40-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/0.10/slim
+0.10-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/0.10/slim
 
-0.10.40-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/0.10/slim
-0.10-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/0.10/slim
+0.12.7-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/0.12/slim
+0.12-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/0.12/slim
 
+4.0.0-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/4.0/slim
+4.0-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/4.0/slim
 
-0.12.7-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/0.12/slim
-0.12-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/0.12/slim
-0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/0.12/slim
-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/0.12/slim
+4.2.4-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/4.2/slim
+4.2-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/4.2/slim
 
-
-4.0.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/4.0/slim
-4.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 amd64/4.0/slim
+5.3.0-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/5.3/slim
+5.3-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 amd64/5.3/slim

--- a/library/armel-node
+++ b/library/armel-node
@@ -1,0 +1,17 @@
+# maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
+# maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
+
+0.10.40-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/0.10/slim
+0.10-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/0.10/slim
+
+0.12.7-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/0.12/slim
+0.12-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/0.12/slim
+
+4.0.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/4.0/slim
+4.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/4.0/slim
+
+4.2.4-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/4.2/slim
+4.2-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/4.2/slim
+
+5.3.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/5.3/slim
+5.3-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armel/5.3/slim

--- a/library/armv7hf-node
+++ b/library/armv7hf-node
@@ -1,15 +1,17 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-0.10.40-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/0.10/slim
-0.10-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/0.10/slim
+0.10.40-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 armv7hf/0.10/slim
+0.10-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 armv7hf/0.10/slim
 
+0.12.7-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 armv7hf/0.12/slim
+0.12-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 armv7hf/0.12/slim
 
-0.12.7-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/0.12/slim
-0.12-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/0.12/slim
-0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/0.12/slim
-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/0.12/slim
+4.0.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armv7hf/4.0/slim
+4.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armv7hf/4.0/slim
 
+4.2.4-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armv7hf/4.2/slim
+4.2-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armv7hf/4.2/slim
 
-4.0.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/4.0/slim
-4.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 armv7hf/4.0/slim
+5.3.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armv7hf/5.3/slim
+5.3-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b armv7hf/5.3/slim

--- a/library/i386-node
+++ b/library/i386-node
@@ -1,15 +1,17 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-0.10.40-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/0.10/slim
-0.10-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/0.10/slim
+0.10.40-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/0.10/slim
+0.10-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/0.10/slim
 
+0.12.7-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/0.12/slim
+0.12-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/0.12/slim
 
-0.12.7-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/0.12/slim
-0.12-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/0.12/slim
-0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/0.12/slim
-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/0.12/slim
+4.0.0-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/4.0/slim
+4.0-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/4.0/slim
 
+4.2.4-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/4.2/slim
+4.2-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/4.2/slim
 
-4.0.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/4.0/slim
-4.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 i386/4.0/slim
+5.3.0-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/5.3/slim
+5.3-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 i386/5.3/slim

--- a/library/rpi-node
+++ b/library/rpi-node
@@ -1,15 +1,17 @@
 # maintainer: Joyent Image Team <image-team@joyent.com> (@joyent)
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-0.10.40-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/0.10/slim
-0.10-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/0.10/slim
+0.10.40-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 rpi/0.10/slim
+0.10-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 rpi/0.10/slim
 
+0.12.7-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 rpi/0.12/slim
+0.12-slim: git://github.com/resin-io-library/docker-node@73f2bcb7b570f67aeff115baa76347cf2106e1c2 rpi/0.12/slim
 
-0.12.7-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/0.12/slim
-0.12-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/0.12/slim
-0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/0.12/slim
-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/0.12/slim
+4.0.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b rpi/4.0/slim
+4.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b rpi/4.0/slim
 
+4.2.4-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b rpi/4.2/slim
+4.2-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b rpi/4.2/slim
 
-4.0.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/4.0/slim
-4.0-slim: git://github.com/resin-io-library/docker-node@28aeb0b59cae208db1f70a4545b2198ffb040093 rpi/4.0/slim
+5.3.0-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b rpi/5.3/slim
+5.3-slim: git://github.com/resin-io-library/docker-node@98dbb6833b90f8fc5cb5953734cd45a25605896b rpi/5.3/slim


### PR DESCRIPTION
- Add armel-node.
- Add Node v4.2.4 and v5.3.0