### PR TITLE
Autogenerated libs - Fix exit code issue in debian entry script

### DIFF
--- a/library/aarch64-debian
+++ b/library/aarch64-debian
@@ -1,4 +1,4 @@
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-jessie: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/aarch64/jessie
-latest: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/aarch64/jessie
+jessie: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/aarch64/jessie
+latest: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/aarch64/jessie

--- a/library/amd64-debian
+++ b/library/amd64-debian
@@ -1,6 +1,6 @@
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-jessie: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/amd64/jessie
-latest: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/amd64/jessie
+jessie: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/amd64/jessie
+latest: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/amd64/jessie
 
 wheezy: git://github.com/resin-io-library/base-images@6da86d75ca4ae14741ca80c743bfa0277dc4f6dd debian/amd64/wheezy

--- a/library/armel-debian
+++ b/library/armel-debian
@@ -1,6 +1,6 @@
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-jessie: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/armel/jessie
-latest: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/armel/jessie
+jessie: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/armel/jessie
+latest: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/armel/jessie
 
 wheezy: git://github.com/resin-io-library/base-images@6da86d75ca4ae14741ca80c743bfa0277dc4f6dd debian/armel/wheezy

--- a/library/armv7hf-debian
+++ b/library/armv7hf-debian
@@ -1,8 +1,8 @@
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-jessie: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/armv7hf/jessie
-latest: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/armv7hf/jessie
+jessie: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/armv7hf/jessie
+latest: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/armv7hf/jessie
 
-sid: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/armv7hf/sid
+sid: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/armv7hf/sid
 
 wheezy: git://github.com/resin-io-library/base-images@6da86d75ca4ae14741ca80c743bfa0277dc4f6dd debian/armv7hf/wheezy

--- a/library/i386-debian
+++ b/library/i386-debian
@@ -1,6 +1,6 @@
 # maintainer: Trong Nghia Nguyen - resin.io <james@resin.io>
 
-jessie: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/i386/jessie
-latest: git://github.com/resin-io-library/base-images@c3efc3b3f7d449b2688cd2f2ccbd6732f39f7759 debian/i386/jessie
+jessie: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/i386/jessie
+latest: git://github.com/resin-io-library/base-images@ec5e43680a03fb33f2290c9d6ea31723187573a3 debian/i386/jessie
 
 wheezy: git://github.com/resin-io-library/base-images@6da86d75ca4ae14741ca80c743bfa0277dc4f6dd debian/i386/wheezy


### PR DESCRIPTION
Connects to https://github.com/resin-io-library/base-images/pull/192 and https://github.com/resin-io-library/base-images/pull/191